### PR TITLE
Push run logic into settings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@ mod tui;
 
 pub use errors::Error;
 
-use crate::settings::ServiceOperation;
-
 pub type Result<T> = color_eyre::eyre::Result<T, Error>;
 
 pub async fn run() -> Result<()> {
@@ -17,74 +15,7 @@ pub async fn run() -> Result<()> {
 
     tracing::info!("Starting up");
 
-    let settings = settings::Settings::parse()?;
-
-    match settings.cli.command {
-        settings::Command::Debug => {
-            tracing::info!("Debugging");
-
-            println!("{:#?}", settings);
-        }
-        settings::Command::Tui => {
-            tracing::info!("Starting TUI");
-
-            tui::init().await?;
-        }
-        settings::Command::Server(server_details) => {
-            tracing::info!("Server command: {:?}", server_details);
-
-            match server_details.mode {
-                Some(mode) => mode.exec(server_details.settings).await?,
-                None => {
-                    tracing::info!("No server mode specified, prompting");
-
-                    settings::ServerMode::select()?
-                        .exec(server_details.settings)
-                        .await?;
-                }
-            }
-        }
-        settings::Command::Client(client_details) => {
-            tracing::info!("Client command");
-
-            match client_details.resource {
-                Some(resource) => resource.exec(client_details.settings).await?,
-                None => {
-                    tracing::info!("No client resource specified, prompting");
-
-                    settings::ClientResource::select()?
-                        .exec(client_details.settings)
-                        .await?;
-                }
-            }
-        }
-        settings::Command::Service(service_details) => {
-            tracing::info!("Service command: {:?}", service_details);
-
-            // get the whereabouts of the current executable binary
-            let program = std::env::current_exe()?;
-            let args = vec![
-                "-a".into(),
-                settings.cli.global.app_name.clone().into(),
-                "server".into(),
-                "api".into(),
-            ];
-            let service = service::Service::init(
-                service_details
-                    .settings
-                    .service_label
-                    .unwrap_or_else(|| format!("local.service.{}", settings.cli.global.app_name))
-                    .parse()?,
-            )?;
-
-            match service_details.operation {
-                ServiceOperation::Install => service.install(program, args)?,
-                ServiceOperation::Start => service.start()?,
-                ServiceOperation::Stop => service.stop()?,
-                ServiceOperation::Uninstall => service.uninstall()?,
-            }
-        }
-    }
+    settings::Settings::parse()?.exec().await?;
 
     Ok(())
 }


### PR DESCRIPTION
This is probably just a step towards a better overall shape, but it seemed like the run function in lib was doing too much. It also seems like settings is doing too much, now, so it might make sense to seek a better structure for that. Still, this puts us in a spot where we can refactor the responsibility of individual components into their respective packages.