### PR TITLE
Add sqlite file storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "service-manager",
  "sqlx",
  "strum",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2653,6 +2654,8 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",
@@ -2694,6 +2697,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -3058,6 +3062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ dialoguer = { version = "0.11.0", features = [
   "fuzzy-select",
 ] }
 dirs = "5.0.1"
+derive_builder = "0.20.0"
 duct = "0.13"
 futures = "0.3.30"
 getrandom = { version = "0.2", features = ["js"] }
@@ -44,8 +45,10 @@ sqlx = { version = "0.7.3", features = [
   "uuid",
   "tls-rustls",
   "chrono",
+  "runtime-tokio",
 ] }
 strum = { version = "0.26.2", features = ["derive"] }
+tempfile = "3"
 thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = "0.7.10"
@@ -61,3 +64,4 @@ tracing-subscriber = { version = "0.3.18", features = [
 tui-textarea = "0.4.0"
 wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.42"
+zip = "2.1"

--- a/service-kit-core/Cargo.toml
+++ b/service-kit-core/Cargo.toml
@@ -6,54 +6,36 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.7.5", features = ["ws", "tracing", "tokio"] }
-axum-extra = { version = "0.9", features = ["typed-header"] }
-chrono = { version = "0.4.33", features = ["serde"] }
-clap = { version = "4.5.4", features = ["derive", "env"] }
-color-eyre = "0.6.2"
-config = "0.14.0"
-crossterm = { version = "0.27.0", features = ["event-stream", "serde"] }
-dialoguer = { version = "0.11.0", features = [
-  "history",
-  "fuzzy-matcher",
-  "completion",
-  "fuzzy-select",
-] }
-dirs = "5.0.1"
-futures = "0.3.30"
-indicatif = { version = "0.17.8", features = ["tokio"] }
-mime_guess = "2.0.4"
-rand = "0.8"
-ratatui = { version = "0.26.2", features = [
-  "all-widgets",
-  "macros",
-  "serde",
-  "crossterm",
-] }
-reqwest = { version = "0.12", features = ["json"] }
-rust-embed = { version = "8", features = ["axum-ex"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-service-manager = { version = "0.6.1", features = ["clap", "serde"] }
-sqlx = { version = "0.7.3", features = [
-  "sqlite",
-  "uuid",
-  "tls-rustls",
-  "chrono",
-] }
-strum = { version = "0.26.2", features = ["derive"] }
-thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["full"] }
-tokio-util = "0.7.10"
-tower-http = "0.5.2"
-tracing = { version = "0.1.40", features = ["log"] }
-tracing-subscriber = { version = "0.3.18", features = [
-  "chrono",
-  "json",
-  "env-filter",
-  "serde",
-  "serde_json",
-] }
-tui-textarea = "0.4.0"
-wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.42"
+axum = { workspace = true }
+axum-extra = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+config = { workspace = true }
+crossterm = { workspace = true }
+dialoguer = { workspace = true }
+dirs = { workspace = true }
+futures = { workspace = true }
+indicatif = { workspace = true }
+mime_guess = { workspace = true }
+rand = { workspace = true }
+ratatui = { workspace = true }
+reqwest = { workspace = true }
+rust-embed = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+service-manager = { workspace = true }
+sqlx = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tui-textarea = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/service-kit-core/src/context.rs
+++ b/service-kit-core/src/context.rs
@@ -1,0 +1,27 @@
+#[derive(Clone, Debug)]
+pub struct WebContext {
+    pub settings: crate::settings::Settings,
+    pub network: crate::settings::NetworkSettings,
+    pub storage: crate::storage::StorageCollection,
+}
+
+impl WebContext {
+    pub async fn new(
+        network: crate::settings::NetworkSettings,
+        settings: crate::settings::Settings,
+    ) -> crate::Result<Self> {
+        Ok(Self {
+            network,
+            storage: crate::storage::StorageCollection::file_index(settings.storage_path()).await?,
+            settings,
+        })
+    }
+
+    pub async fn listener(&self) -> crate::Result<tokio::net::TcpListener> {
+        self.network.listener().await
+    }
+
+    pub fn settings(&self) -> &crate::settings::Settings {
+        &self.settings
+    }
+}

--- a/service-kit-core/src/errors.rs
+++ b/service-kit-core/src/errors.rs
@@ -8,6 +8,10 @@ pub enum Error {
     ClapError(#[from] clap::Error),
     #[error("SQLx error: {0}")]
     SqlxError(#[from] sqlx::Error),
+    #[error("Storage error: {0}")]
+    StorageError(#[from] crate::storage::StorageError),
+    #[error("Storage not configured, unable to initialize storage collection")]
+    StorageNotConfiguredError,
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("Unable to get next terminal event")]

--- a/service-kit-core/src/lib.rs
+++ b/service-kit-core/src/lib.rs
@@ -1,12 +1,15 @@
 mod client;
+mod context;
 mod errors;
 mod server;
 mod service;
 mod settings;
+mod storage;
 mod telemetry;
 mod tui;
 
 pub use client::WebClient;
+pub use context::WebContext;
 pub use errors::Error;
 
 pub type Result<T> = color_eyre::eyre::Result<T, Error>;

--- a/service-kit-core/src/server.rs
+++ b/service-kit-core/src/server.rs
@@ -2,18 +2,17 @@ use std::net::SocketAddr;
 
 use axum::Router;
 
-use crate::settings::NetworkSettings;
-
 pub mod api;
 pub mod full;
 pub mod web;
 
-pub async fn init(config: NetworkSettings) -> crate::Result<()> {
+pub async fn init(context: crate::WebContext) -> crate::Result<()> {
     let app = Router::new()
-        .merge(api::router(config.clone()).await)
-        .merge(web::router(config.clone()).await);
+        .merge(web::router(context.clone()).await)
+        .merge(api::router(context.clone()).await)
+        .with_state(context.clone());
 
-    let listener = config.listener().await?;
+    let listener = context.listener().await?;
 
     axum::serve(
         listener,

--- a/service-kit-core/src/server/api.rs
+++ b/service-kit-core/src/server/api.rs
@@ -1,15 +1,13 @@
 use axum::{routing::get, Router};
 use std::net::SocketAddr;
 
-use crate::settings::NetworkSettings;
-
-pub async fn router(_config: NetworkSettings) -> Router {
+pub async fn router(_context: crate::WebContext) -> Router<crate::WebContext> {
     Router::new().route("/health", get(|| async { "OK" }))
 }
 
-pub async fn init(config: NetworkSettings) -> crate::Result<()> {
-    let app = router(config.clone()).await;
-    let listener = config.listener().await?;
+pub async fn init(context: crate::WebContext) -> crate::Result<()> {
+    let app = router(context.clone()).await.with_state(context.clone());
+    let listener = context.listener().await?;
 
     axum::serve(
         listener,

--- a/service-kit-core/src/server/web.rs
+++ b/service-kit-core/src/server/web.rs
@@ -3,15 +3,13 @@ mod assets;
 use axum::Router;
 use std::net::SocketAddr;
 
-use crate::settings::NetworkSettings;
-
-pub async fn router(config: NetworkSettings) -> Router {
-    Router::new().merge(assets::router(config.clone()).await)
+pub async fn router(context: crate::WebContext) -> Router<crate::WebContext> {
+    Router::new().merge(assets::router(context.clone()).await)
 }
 
-pub async fn init(config: NetworkSettings) -> crate::Result<()> {
-    let app = router(config.clone()).await;
-    let listener = config.listener().await?;
+pub async fn init(context: crate::WebContext) -> crate::Result<()> {
+    let app = router(context.clone()).await.with_state(context.clone());
+    let listener = context.listener().await?;
 
     axum::serve(
         listener,

--- a/service-kit-core/src/storage.rs
+++ b/service-kit-core/src/storage.rs
@@ -1,0 +1,43 @@
+mod storage_collection;
+mod storage_error;
+mod storage_file;
+mod storage_path;
+
+pub use storage_collection::StorageCollection;
+pub use storage_error::StorageError;
+pub use storage_file::StorageFile;
+pub use storage_path::StoragePath;
+
+#[cfg(test)]
+mod test {
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn file_collections() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let new_db = temp_dir.path().join("new.db");
+
+        // touch the file to make sure it exists
+        std::fs::File::create(&new_db).expect("Failed to create temp db file");
+
+        let collection = super::StorageCollection::file_index(new_db).await?;
+
+        collection
+            .insert("/base/hello.md".parse()?, "Hello, world!".as_bytes().into())
+            .await?;
+
+        let file = collection.get("/base/hello.md".parse()?).await?;
+
+        assert_eq!(file.name, "hello.md");
+        assert_eq!(file.size, 13);
+        assert_eq!(file.contents, "Hello, world!".as_bytes());
+
+        collection.remove("/base/hello.md".parse()?).await?;
+
+        let file = collection.get("/base/hello.md".parse()?).await;
+
+        assert!(file.is_err());
+
+        Ok(())
+    }
+}

--- a/service-kit-core/src/storage/sql/collection.sql
+++ b/service-kit-core/src/storage/sql/collection.sql
@@ -1,0 +1,11 @@
+create table if not exists files (
+  id         integer    primary key autoincrement,
+  name       text       not null,
+  path       text       not null,
+  size       integer    not null,
+  contents   blob       not null,
+  created_at timestamp  default current_timestamp,
+  updated_at timestamp  default current_timestamp
+);
+
+create unique index if not exists files_name_path on files (name, path);

--- a/service-kit-core/src/storage/storage_collection.rs
+++ b/service-kit-core/src/storage/storage_collection.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+
+use super::{StorageFile, StoragePath};
+
+#[derive(Clone, Debug)]
+pub struct StorageCollection {
+    pub pool: sqlx::SqlitePool,
+}
+
+async fn get_connection(url: impl AsRef<str>) -> crate::Result<sqlx::SqlitePool> {
+    let pool = sqlx::sqlite::SqlitePool::connect(url.as_ref()).await?;
+    let migration = include_str!("./sql/collection.sql");
+
+    sqlx::query(migration).execute(&pool).await?;
+
+    Ok(pool)
+}
+
+impl StorageCollection {
+    pub async fn file_index(new_db: PathBuf) -> crate::Result<Self> {
+        let pool = get_connection(format!("{}", new_db.display())).await?;
+        let collection = StorageCollection { pool };
+
+        collection
+            .insert("/example.md".parse()?, "Hello, world!".as_bytes().into())
+            .await?;
+
+        Ok(collection)
+    }
+
+    pub async fn insert(&self, path: StoragePath, contents: Vec<u8>) -> crate::Result<()> {
+        let insert_or_update = r#"
+            insert into files
+                (name, path, size, contents) 
+            values
+                ($1, $2, $3, $4)
+            on conflict(name, path) do
+                update set
+                    size = excluded.size, 
+                    contents = excluded.contents
+            "#;
+
+        path.expect_absolute()?;
+
+        sqlx::query(insert_or_update)
+            .bind(&path.file_name()?)
+            .bind(&path.parent()?.to_string())
+            .bind(contents.len() as i64)
+            .bind(contents)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn len(&self) -> crate::Result<usize> {
+        let count: (i64,) = sqlx::query_as("select count(*) from files")
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(count.0 as usize)
+    }
+
+    pub async fn all(&self) -> crate::Result<Vec<StorageFile>> {
+        let files = sqlx::query_as::<_, StorageFile>("select * from files")
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(files)
+    }
+
+    pub async fn get(&self, path: StoragePath) -> crate::Result<StorageFile> {
+        path.expect_absolute()?;
+
+        let file =
+            sqlx::query_as::<_, StorageFile>("select * from files where path = $1 and name = $2")
+                .bind(&path.parent()?.to_string())
+                .bind(&path.file_name()?)
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(file)
+    }
+
+    pub async fn remove(&self, path: StoragePath) -> crate::Result<()> {
+        path.expect_absolute()?;
+
+        sqlx::query("delete from files where path = $1 and name = $2")
+            .bind(&path.parent()?.to_string())
+            .bind(&path.file_name()?)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/service-kit-core/src/storage/storage_error.rs
+++ b/service-kit-core/src/storage/storage_error.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("missing file name")]
+    MissingFileName,
+    #[error("invalid file name")]
+    InvalidFileName,
+    #[error("missing path data")]
+    MissingPathData,
+    #[error("bad path: {0}")]
+    BadPath(PathBuf),
+}

--- a/service-kit-core/src/storage/storage_file.rs
+++ b/service-kit-core/src/storage/storage_file.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, sqlx::FromRow)]
+pub struct StorageFile {
+    pub name: String,
+    pub path: String,
+    pub size: i64,
+    pub contents: Vec<u8>,
+    pub created_at: chrono::NaiveDateTime,
+    pub updated_at: chrono::NaiveDateTime,
+}
+
+impl StorageFile {
+    #[tracing::instrument(level = "debug", skip(context), name = "Getting storage file for path")]
+    pub async fn get(context: &crate::WebContext, path: &str) -> crate::Result<Option<Self>> {
+        Ok(context.storage.get(path.parse()?).await.ok())
+    }
+}

--- a/service-kit-core/src/storage/storage_path.rs
+++ b/service-kit-core/src/storage/storage_path.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use super::StorageError;
+
+pub struct StoragePath(PathBuf);
+
+impl StoragePath {
+    pub fn new(path: PathBuf) -> Self {
+        StoragePath::from(path)
+    }
+
+    fn into_inner(&self) -> PathBuf {
+        self.0.clone()
+    }
+
+    pub fn expect_absolute(&self) -> crate::Result<()> {
+        if !self.0.is_absolute() {
+            return Err(StorageError::BadPath(self.into_inner()))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn parent(&self) -> Result<StoragePath, StorageError> {
+        self.0
+            .parent()
+            .map(|p| StoragePath(p.to_path_buf()))
+            .ok_or(StorageError::MissingPathData)
+    }
+
+    pub fn file_name(&self) -> Result<String, StorageError> {
+        self.0
+            .file_name()
+            .and_then(|f| f.to_str())
+            .map(|f| f.to_string())
+            .ok_or(StorageError::InvalidFileName)
+    }
+}
+
+impl std::str::FromStr for StoragePath {
+    type Err = StorageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StoragePath(PathBuf::from(s)))
+    }
+}
+
+impl std::fmt::Display for StoragePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+impl From<PathBuf> for StoragePath {
+    fn from(path: PathBuf) -> Self {
+        StoragePath(path)
+    }
+}


### PR DESCRIPTION
This is a very minimal implementation of sqlite file storage. The spirit of it is this: instead of storing files on the host server running service kits, we generally want to bundle those files up and use sqlite as a custom file storage format instead. This gives us the ability to make a single service a lot more portable later if we like, eliminating an entire category of issues revolving around file management.

Unfortunately this leaves a lot on the table which I'd hoped to add along with storage, and so I'm leaving a note here that I wish I'd been able to do these things, too:

- Create a single "storage" metaphor that handled memory and file representations both.
- Create a graceful shutdown that copies memory to a separate cache db, and rehydrated on next boot up.
- Allow consumers to access sqlite pools and do their own stuff with them.

I say "unfortunately" not because those are must-haves. I think this might be a better architecture since it'll encourage me to represent different sqlite lifecycles as different types. It's unfortunate because I spent two weeks trying to debug sqlx issues and part of that I thought was my fault. Delays suck!