### PR TITLE
Use protocol types in client.

### DIFF
--- a/service-kit-core/src/client.rs
+++ b/service-kit-core/src/client.rs
@@ -1,15 +1,13 @@
 use crate::settings::NetworkSettings;
+use service_kit_proto::prelude::*;
 
 /// Make a network request with a `NetworkSettings` configuration against the /health endpoint.
 ///
-pub async fn health(config: NetworkSettings) -> crate::Result<()> {
+pub async fn health(config: NetworkSettings) -> crate::Result<HealthCheckResponse> {
     let uri = format!("http://{}/health", config.address());
     let response = reqwest::get(&uri).await?;
-    let body = response.text().await?;
 
-    println!("{}", body);
-
-    Ok(())
+    Ok(response.json::<HealthCheckResponse>().await?)
 }
 
 pub struct WebClient;
@@ -19,7 +17,7 @@ impl WebClient {
         Self
     }
 
-    pub async fn health(&self) -> crate::Result<()> {
+    pub async fn health(&self) -> crate::Result<HealthCheckResponse> {
         health(NetworkSettings {
             host: "localhost".to_string(),
             port: 8080,

--- a/service-kit-core/src/errors.rs
+++ b/service-kit-core/src/errors.rs
@@ -8,6 +8,8 @@ pub enum Error {
     ClapError(#[from] clap::Error),
     #[error("SQLx error: {0}")]
     SqlxError(#[from] sqlx::Error),
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
     #[error("Storage error: {0}")]
     StorageError(#[from] crate::storage::StorageError),
     #[error("Storage not configured, unable to initialize storage collection")]


### PR DESCRIPTION
I forgot to add the protocol types to the rust client. Whoops! I'm also thinking about perhaps pulling the wasm client into the core kit, and reusing it, so that the client operations can be write-once. However, it might be enough just to share the types?